### PR TITLE
Rewrite

### DIFF
--- a/mod.json
+++ b/mod.json
@@ -19,8 +19,8 @@
 	},
 	"dependencies": [
 		{
-			"id": "geode.node-ids",
-			"version": ">=1.18.0",
+			"id": "alphalaneous.alphas_geode_utils",
+			"version": ">=1.0.4",
 			"importance": "required"
 		}
 	]


### PR DESCRIPTION
- No more Node ID dependency
- Less hardcoded checks
- More efficient
- Remove addChild hook (removing the hook overhead overall, so better performance), opting to use Alpha's Geode Utils for the node modifications instead. 
- Handle multiple edge cases to have a cleaner looking scrollbar through multiple mods, such as when they use anchors
- Doesn't loop through scrollbars, instead opting to marking the target with the scrollbar (efficiency)
- Touch prio change that actually works (even hackier, yippee)
- Less unnecessary string comparisons (more performance!)
- Somewhat more readable code
