### PR TITLE
No Scrollbars for CopySizeLayout 😡

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -8,7 +8,7 @@ void addScrollBarToNode(CCNode* self, float offset, CCNode* addTo) {
 	CCNode* parent = self->getParent();
 	if (!addTo) addTo = parent;
 
-	if (CopySizeLayout* copySizeLayout = typeinfo_cast<CopySizeLayout*>(addTo->getLayout())) {
+	if (typeinfo_cast<CopySizeLayout*>(addTo->getLayout())) {
 		return;
 	}
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -8,6 +8,10 @@ void addScrollBarToNode(CCNode* self, float offset, CCNode* addTo) {
 	CCNode* parent = self->getParent();
 	if (!addTo) addTo = parent;
 
+	if (CopySizeLayout* copySizeLayout = typeinfo_cast<CopySizeLayout*>(addTo->getLayout())) {
+		return;
+	}
+
 	if (typeinfo_cast<GJListLayer*>(addTo)) {
 		offset += 20;
 	}


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/66315ec5-1670-4fba-9386-9b6e1a142cee)
CopySizeLayout does weird shit, can't find a good way to resolve it, so just don't add scrollbars to them for now (softlocks android users if they open Jukebox's Index Setting)